### PR TITLE
Improve README with context and PEP references

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 Because the Python ecosystem decided that *simplicity* is a luxury we can’t afford:
 
-1. **Homebrew** ships a Python that silently pushes `--user` installs and breaks virtualenvs.
-2. *pip* still thinks sprinkling global‑user settings everywhere is a good idea.
+1. **Homebrew** used to ship a Python where `pip` defaulted to `--user` installs, confusing virtualenvs. Old guides still assume this behavior.
+2. *pip* honors config files that can force user installs. Stray `pip.conf` entries linger for years.
 3. Scripts call `python3` while toolchains assume `python`. Meanwhile, neither may be the one you actually installed.
 4. You waste hours rage‑googling instead of writing code.
 
@@ -27,6 +27,19 @@ exec $SHELL   # reload zsh so changes take effect
 ```
 
 That’s it. The next time you create a venv, `pip install` **just works** – no `--user` drama.
+
+---
+
+## How We Got Here
+
+Python packaging on macOS has a long history of conflicting defaults:
+
+* **PEP 405** (2012) formalized virtual environments, but many tools kept installing packages globally.
+* Homebrew patched `pip` for years to default to the user site, leading to the infamous “Can not perform a `--user` install” error inside venvs.
+* **PEP 668** (2023) introduced the `EXTERNALLY-MANAGED` marker so package managers can protect system Pythons.
+* By 2025, Homebrew no longer forces `--user`, but old configs and tutorials still do.
+
+This script grew out of that mess. It enforces a clean interpreter via **pyenv** so you can rely on `python -m venv` behaving sanely.
 
 ---
 
@@ -51,15 +64,15 @@ Result: a *sane*, venv‑friendly Python toolchain.
 
 ### “Why can’t `python -m venv` just work on macOS?”
 
-Because the Homebrew maintainers thought defaulting to `--user` installs was *cute*. Guido blessed `pip`’s user‑site dance, and everyone else shrugged. 🤡
+Homebrew’s old `--user` patch collided with pip’s user‑site support from **PEP 370**. Even though the patch is gone, leftover configs still trigger the error.
 
 ### “Can’t I just use the system Python?”
 
-Apple’s `/usr/bin/python3` is SIP‑locked, outdated, and missing headers. Don’t.
+Apple’s `/usr/bin/python3` is protected by SIP. It’s reasonably up to date (Python 3.11 ships with Sonoma) but lacks development headers unless Xcode tools are installed. Many users still prefer an external interpreter.
 
 ### “Isn’t this pyenv setup overkill?”
 
-Maybe – but it’s the one method that consistently sidesteps Homebrew’s madness **and** lets you juggle versions.
+Maybe. pyenv is a convenient way to install multiple Python versions without touching `/usr/bin`. A clean Homebrew or python.org install works too as long as you avoid `--user` settings.
 
 ### “I still get the error!”
 
@@ -72,6 +85,14 @@ printenv | grep -E 'PIP_|PYTHON'
 ```
 
 If any path isn’t in `~/.pyenv/shims` or `global.user=true` re‑appears, congrats – another tool rewrote your config. Re‑run the script. 🔪
+
+As of **PEP 668**, package managers may mark their Python as externally managed. If you see that warning, create a virtual environment or use pyenv’s interpreter.
+
+---
+
+## Does This Still Matter in 2025?
+
+Mostly yes. Homebrew no longer forces `--user` installs and system Pythons are newer, but stray configuration files still break venvs. This script remains a quick way to reset your setup with pyenv so you can focus on coding instead of troubleshooting.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Python Env Sanitizer for macOS 🩸
 
-> **TL;DR** – One shell script to end the nightmare of broken *pip*, cursed Homebrew Pythons, and the endless “Can not perform a `--user` install” tragedy. Run it, reload your shell, and get back to shipping code.
+> **TL;DR** – One shell script to end the nightmare of broken *pip*, mismatched Homebrew Pythons, and the endless “Can not perform a `--user` install” tragedy. Run it, reload your shell, and get back to shipping code.
 
 ---
 
@@ -8,12 +8,12 @@
 
 Because the Python ecosystem decided that *simplicity* is a luxury we can’t afford:
 
-1. **Homebrew** used to ship a Python where `pip` defaulted to `--user` installs, confusing virtualenvs. Old guides still assume this behavior.
-2. *pip* honors config files that can force user installs. Stray `pip.conf` entries linger for years.
+1. **Homebrew** once patched `pip` so `pip install` acted as `--user` by default, confusing virtualenvs. That patch was dropped years ago, but old guides still assume it.
+2. *pip* respects per-user or global config files (e.g. `~/.pip/pip.conf`) that can force `--user` installs. Stray entries linger for years.
 3. Scripts call `python3` while toolchains assume `python`. Meanwhile, neither may be the one you actually installed.
 4. You waste hours rage‑googling instead of writing code.
 
-This repo exists so you can point to it and say, “See? It’s *not me* – it’s a clown‑car of conflicting defaults.”
+This repo exists so you can point to it and say, “See? It’s *not me* – it’s a maze of conflicting defaults.”
 
 ---
 
@@ -35,9 +35,9 @@ That’s it. The next time you create a venv, `pip install` **just works** – n
 Python packaging on macOS has a long history of conflicting defaults:
 
 * **PEP 405** (2012) formalized virtual environments, but many tools kept installing packages globally.
-* Homebrew patched `pip` for years to default to the user site, leading to the infamous “Can not perform a `--user` install” error inside venvs.
+* Homebrew patched `pip` for years (around 2016–2020) to default to the user site, leading to the infamous “Can not perform a `--user` install” error inside venvs.
 * **PEP 668** (2023) introduced the `EXTERNALLY-MANAGED` marker so package managers can protect system Pythons.
-* By 2025, Homebrew no longer forces `--user`, but old configs and tutorials still do.
+* By 2025, Homebrew no longer forces `--user`; pip defaults to the main prefix but prints a warning. Old configs and tutorials still assume the patch exists.
 
 This script grew out of that mess. It enforces a clean interpreter via **pyenv** so you can rely on `python -m venv` behaving sanely.
 
@@ -68,7 +68,7 @@ Homebrew’s old `--user` patch collided with pip’s user‑site support from *
 
 ### “Can’t I just use the system Python?”
 
-Apple’s `/usr/bin/python3` is protected by SIP. It’s reasonably up to date (Python 3.11 ships with Sonoma) but lacks development headers unless Xcode tools are installed. Many users still prefer an external interpreter.
+Apple’s `/usr/bin/python3` is protected by SIP. It’s reasonably up to date (Python 3.11 ships with Sonoma) but lacks development headers unless Xcode tools are installed. With **PEP 668**, it may also warn that the interpreter is externally managed when you try to install packages globally. Many users still prefer an external interpreter.
 
 ### “Isn’t this pyenv setup overkill?”
 
@@ -92,7 +92,7 @@ As of **PEP 668**, package managers may mark their Python as externally managed
 
 ## Does This Still Matter in 2025?
 
-Mostly yes. Homebrew no longer forces `--user` installs and system Pythons are newer, but stray configuration files still break venvs. This script remains a quick way to reset your setup with pyenv so you can focus on coding instead of troubleshooting.
+Mostly yes. Homebrew no longer forces `--user` installs and system Pythons ship newer versions (Sonoma bundles Python 3.11 as of 2025), but stray configuration files still break venvs. This script remains a quick way to reset your setup with pyenv so you can focus on coding instead of troubleshooting.
 
 ---
 


### PR DESCRIPTION
## Summary
- explain historical Homebrew/`pip` quirks
- document PEPs and clarify system Python status
- add section about 2025 relevance

## Testing
- `bash -n sanitize_py.sh`


------
https://chatgpt.com/codex/tasks/task_e_684b0374bb68832e9ff2ae0268bf4c7e